### PR TITLE
Raise an exception when the header cannot be parsed

### DIFF
--- a/mimeparse.py
+++ b/mimeparse.py
@@ -26,6 +26,10 @@ __license__ = 'MIT License'
 __credits__ = ''
 
 
+class MimeTypeParseException(Exception):
+    pass
+
+
 def parse_mime_type(mime_type):
     """Parses a mime-type into its component parts.
 
@@ -45,6 +49,10 @@ def parse_mime_type(mime_type):
     # single '*'. Turn it into a legal wildcard.
     if full_type == '*':
         full_type = '*/*'
+
+    if '/' not in full_type:
+        raise MimeTypeParseException(u"Can't parse type \"{}\"".format(full_type))
+
     (type, subtype) = full_type.split('/')
 
     return (type.strip(), subtype.strip(), params)

--- a/mimeparse_test.py
+++ b/mimeparse_test.py
@@ -16,45 +16,58 @@ __author__ = 'Ade Oshineye'
 __email__ = "ade@oshineye.com"
 __credits__ = ""
 
+class MimeParseTestCase(unittest.TestCase):
 
-def test_parse_media_range(args, expected):
-    expected = tuple(expected)
-    result = mimeparse.parse_media_range(args)
-    message = "Expected: '%s' but got %s" % (expected, result)
-    assert expected == result, message
+    def setUp(self):
+        super(MimeParseTestCase, self).setUp()
+        with open("testdata.json") as f:
+            self.test_data = json.load(f)
 
-
-def test_quality(args, expected):
-    result = mimeparse.quality(args[0], args[1])
-    message = "Expected: '%s' but got %s" % (expected, result)
-    assert expected == result, message
-
-
-def test_best_match(args, expected):
-    result = mimeparse.best_match(args[0], args[1])
-    message = "Expected: '%s' but got %s" % (expected, result)
-    assert expected == result, message
+    def _test_parse_media_range(self, args, expected):
+        expected = tuple(expected)
+        result = mimeparse.parse_media_range(args)
+        message = "Expected: '%s' but got %s" % (expected, result)
+        self.assertEqual(expected, result, message)
 
 
-def test_parse_mime_type(args, expected):
-    expected = tuple(expected)
-    result = mimeparse.parse_mime_type(args)
-    message = "Expected: '%s' but got %s" % (expected, result)
-    assert expected == result, message
+    def _test_quality(self, args, expected):
+        result = mimeparse.quality(args[0], args[1])
+        message = "Expected: '%s' but got %s" % (expected, result)
+        self.assertEqual(expected, result, message)
 
 
-def add_tests(suite, json_object, func_name, test_func):
-    test_data = json_object[func_name]
-    for test_datum in test_data:
-        args, expected = test_datum[0], test_datum[1]
-        desc = "%s(%s) with expected result: %s" % (func_name, str(args),
-                                                    str(expected))
-        if len(test_datum) == 3:
-            desc = test_datum[2] + " : " + desc
-        func = partial(test_func, *(args, expected))
-        testcase = unittest.FunctionTestCase(func, description=desc)
-        suite.addTest(testcase)
+    def _test_best_match(self, args, expected, description):
+        if expected is None:
+            self.assertRaises(mimeparse.MimeTypeParseException, mimeparse.best_match, args[0], args[1])
+        else:
+            result = mimeparse.best_match(args[0], args[1])
+            message = "Expected: '%s' but got %s. Description for this test: %s" % (expected, result, description)
+            self.assertEqual(expected, result, message)
 
+    def _test_parse_mime_type(self, args, expected):
+        if expected is None:
+            self.assertRaises(mimeparse.MimeTypeParseException, mimeparse.parse_mime_type, args)
+        else:
+            expected = tuple(expected)
+            result = mimeparse.parse_mime_type(args)
+            message = "Expected: '%s' but got %s" % (expected, result)
+            self.assertEqual(expected, result, message)
+
+    def test_parse_media_range(self):
+        for args, expected in self.test_data['parse_media_range']:
+            self._test_parse_media_range(args, expected)
+
+    def test_quality(self):
+        for args, expected in self.test_data['quality']:
+            self._test_quality(args, expected)
+
+    def test_best_match(self):
+        for args, expected, description in self.test_data['best_match']:
+            self._test_best_match(args, expected, description)
+
+    def test_parse_mime_type(self):
+        for args, expected in self.test_data['parse_mime_type']:
+            self._test_parse_mime_type(args, expected)
 
 def run_tests():
     json_object = json.load(open("testdata.json"))
@@ -69,5 +82,5 @@ def run_tests():
     test_runner.run(suite)
 
 
-if __name__ == "__main__":
-    run_tests()
+if __name__ == '__main__':
+    unittest.main()

--- a/testdata.json
+++ b/testdata.json
@@ -34,11 +34,13 @@
     [[["image/*", "application/xml"], "image/*"], "image/*", "match using a wildcard for both requested and supported"],
     [[["image/jpeg", "text/plain"], "text/*;q=0.3, text/html;q=0.7, text/html;level=1, text/html;level=2;q=0.4, */*;q=0.5"], "image/jpeg", "media type with highest associated quality factor should win, not necessarily most specific"],
     [[["text/html", "application/rdf+xml"], "text/html, application/rdf+xml"], "application/rdf+xml", "match should use highest order of supported when there is a tie"],
-    [[["application/rdf+xml", "text/html"], "text/html, application/rdf+xml"], "text/html", "match should use highest order of supported when there is a tie"]
+    [[["application/rdf+xml", "text/html"], "text/html, application/rdf+xml"], "text/html", "match should use highest order of supported when there is a tie"],
+    [[["application/json", "text/html"], "text"], null, "match should use the default if an invalid Accept header is passed"]
 ],
 
 "parse_mime_type": [
     ["application/xhtml;q=0.5", ["application", "xhtml", {"q": "0.5"}]],
-    ["application/xhtml;q=0.5;ver=1.2", ["application", "xhtml", {"q": "0.5", "ver": "1.2"}]]
+    ["application/xhtml;q=0.5;ver=1.2", ["application", "xhtml", {"q": "0.5", "ver": "1.2"}]],
+    ["text", null]
 ]
 }


### PR DESCRIPTION
Also refactors unit tests so that they produce an expected output upon success *and* failure.

The main rationale behind `MimeTypeParseException` is that if somebody sends a request as follows:

`requests.get(url, headers={ 'Accept': 'text' })`

... the server should respond with a 400 saying that the header is not formatted properly. Right now, we'd have to do the validation outside of the library (introducing somewhat duplicate code) or we'd have to catch a `ValueError` (because `(type, subtype) = full_type.split('/')` would raise `ValueError: need more than 1 value to unpack`), which is too generic. Merging this PR will help me submit a similar PR to https://github.com/martinblech/mimerender utilizing the new exception type and returning a valid response.