### PR TITLE
MimeTypeParseException should inherit from ValueError

### DIFF
--- a/mimeparse.py
+++ b/mimeparse.py
@@ -26,7 +26,7 @@ __license__ = 'MIT License'
 __credits__ = ''
 
 
-class MimeTypeParseException(Exception):
+class MimeTypeParseException(ValueError):
     pass
 
 


### PR DESCRIPTION
Fixes a backward-incompatible change in https://github.com/dbtsai/python-mimeparse/pull/8 by making `MimeTypeParseException` inherit from `ValueError` (previously thrown exception).