### PR TITLE
Mimeparse should gracefully handle an invalid mime type of the form "text/extra/part"

### DIFF
--- a/mimeparse.py
+++ b/mimeparse.py
@@ -50,10 +50,11 @@ def parse_mime_type(mime_type):
     if full_type == '*':
         full_type = '*/*'
 
-    if '/' not in full_type:
+    type_parts = full_type.split('/') if '/' in full_type else None
+    if not type_parts or len(type_parts) > 2:
         raise MimeTypeParseException("Can't parse type \"{}\"".format(full_type))
 
-    (type, subtype) = full_type.split('/')
+    (type, subtype) = type_parts
 
     return (type.strip(), subtype.strip(), params)
 

--- a/testdata.json
+++ b/testdata.json
@@ -41,6 +41,7 @@
 "parse_mime_type": [
     ["application/xhtml;q=0.5", ["application", "xhtml", {"q": "0.5"}]],
     ["application/xhtml;q=0.5;ver=1.2", ["application", "xhtml", {"q": "0.5", "ver": "1.2"}]],
-    ["text", null]
+    ["text", null],
+    ["text/something/invalid", null]
 ]
 }


### PR DESCRIPTION
Hi @dbtsai. See the added test data to understand the use case. Could you merge + make a release?