### PR TITLE
let acceptable types specify their quality

### DIFF
--- a/mimeparse.py
+++ b/mimeparse.py
@@ -110,6 +110,9 @@ def quality_and_fitness_parsed(mime_type, parsed_ranges):
             ])
             fitness += param_matches
 
+            # finally, add the target's "q" param (between 0 and 1)
+            fitness += float(target_params.get('q', 1))
+
             if fitness > best_fitness:
                 best_fitness = fitness
                 best_fit_q = params['q']

--- a/testdata.json
+++ b/testdata.json
@@ -167,6 +167,14 @@
         ],
         [
             [
+                ["application/json;q=1.0", "text/html;q=0.9", "text/plain;q=0.1"],
+                "*/*"
+            ],
+            "application/json;q=1.0",
+            "*/* match should pick an acceptable type with the highest quality"
+        ],
+        [
+            [
                 ["application/json", "text/html"],
                 "text"
             ],

--- a/testdata.json
+++ b/testdata.json
@@ -196,6 +196,14 @@
         ],
         [
             [
+                ["text/html;q=0.9", "application/json", "text/plain;q=0.1"],
+                "*/*"
+            ],
+            "application/json",
+            "*/* match should pick an acceptable type with the highest quality, even if it's implicit"
+        ],
+        [
+            [
                 ["application/json", "text/html"],
                 "text"
             ],


### PR DESCRIPTION
This way, we allow applications server-side to define what is the most desirable mime type in cases where `*/*` was requested.

As [RFC 7231 Section 5.3.1](https://tools.ietf.org/html/rfc7231#section-5.3.1) says:

> This weight is referred to as a "quality value" (or "qvalue") because the same parameter name is often used within server configurations to assign a weight to the relative quality of the various representations that can be selected for a resource.
