### PR TITLE
Ignore more dirs in flake8 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ basepython = pypy3
 [testenv:flake8]
 deps = flake8
        flake8-import-order
-commands = flake8 --statistics --show-source --ignore=E501 --exclude=.venv,.tox,*egg .
+commands = flake8 --statistics --show-source --ignore=E501 --exclude=.venv,.tox,*egg,*.egg-info,build,dist .


### PR DESCRIPTION
There's additionally venv in .gitignore, maybe that should be added as well? On the other hand, .venv (with a leading dot) is ignored here, but that's not in .gitignore...