### PR TITLE
Add python_requires to help pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Use **pip**:
 
     $ pip install python-mimeparse
 
-It supports Python 2.7 - 3.5 and PyPy.
+It supports Python 2.7, 3.4+ and PyPy.
 
 Functions
 ---------

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     download_url=("https://github.com/dbtsai/python-mimeparse/tarball/" +
                   version),
     keywords=["mime-type"],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This helps pip install the correct version of the package depending on the user's Python version.

See https://packaging.python.org/guides/dropping-older-python-versions/ for more info.