### PR TITLE
Add license to the setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     description=("A module provides basic functions for parsing mime-type "
                  "names and matching them against a list of media-ranges."),
     author="DB Tsai",
-    license="MIT"
+    license="MIT",
     author_email="dbtsai@dbtsai.com",
     url="https://github.com/dbtsai/python-mimeparse",
     download_url=("https://github.com/dbtsai/python-mimeparse/tarball/" +


### PR DESCRIPTION
In order to make automatic checking of license compliance faster, add license to the setup arguments.